### PR TITLE
feat: replace httpx with zapros

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # db
     "sqlalchemy[asyncio,postgresql-asyncpg]>=2.0.45",
     # http client for middleware
-    "zapros>=0.11.0",
+    "zapros>=0.11.1",
     # other
     "pydantic-settings>=2.12.0",
     "dishka>=1.7.2",
@@ -102,10 +102,6 @@ exclude = ["taskiq_dashboard/api/styles"]
 source = "versioningit"
 
 [tool.hatch.build.hooks.custom]
-
-# TODO: remove this after 0.11.1 version will be released
-[tool.uv.sources]
-zapros = { git = "https://github.com/kap-sh/zapros", rev = "f35c63bfbe3975ebee3b2de7cbf51a3bb1ffc1d0" }  # pragma: allowlist secret
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # db
     "sqlalchemy[asyncio,postgresql-asyncpg]>=2.0.45",
     # http client for middleware
-    "httpx>=0.28.1",
+    "zapros>=0.11.0",
     # other
     "pydantic-settings>=2.12.0",
     "dishka>=1.7.2",
@@ -79,8 +79,6 @@ test = [
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
     "pytest-deadfixtures>=3.1.0",
-    # for request mocking
-    "pytest-httpx>=0.36.2",
     # for test databases management
     "psycopg2-binary>=2.9.12",
     "sqlalchemy-utils>=0.42.1",
@@ -105,7 +103,9 @@ source = "versioningit"
 
 [tool.hatch.build.hooks.custom]
 
-
+# TODO: remove this after 0.11.1 version will be released
+[tool.uv.sources]
+zapros = { git = "https://github.com/kap-sh/zapros", rev = "f35c63bfbe3975ebee3b2de7cbf51a3bb1ffc1d0" }  # pragma: allowlist secret
 
 [tool.ruff]
 line-length = 120

--- a/taskiq_dashboard/interface/middleware.py
+++ b/taskiq_dashboard/interface/middleware.py
@@ -1,17 +1,31 @@
 import asyncio
+import sys
 from datetime import datetime, timezone
 from logging import getLogger
-from typing import Any
+from typing import Any, TypedDict
 from urllib.parse import urljoin
 
-import httpx
+import zapros
 from taskiq.abc.middleware import TaskiqMiddleware
 from taskiq.compat import model_dump
 from taskiq.message import TaskiqMessage
 from taskiq.result import TaskiqResult
 
 
+if sys.version_info >= (3, 11):
+    from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
+
+
 logger = getLogger('taskiq_dashboard.admin_middleware')
+
+
+class Timeout(TypedDict):
+    total_timeout: NotRequired[float]
+    connect_timeout: NotRequired[float]
+    read_timeout: NotRequired[float]
+    write_timeout: NotRequired[float]
 
 
 class DashboardMiddleware(TaskiqMiddleware):
@@ -34,25 +48,26 @@ class DashboardMiddleware(TaskiqMiddleware):
         self,
         url: str,
         api_token: str,
-        timeout: float = 5.0,
+        timeout: float | Timeout = 5.0,
         broker_name: str = 'default_broker',
     ) -> None:
         super().__init__()
         self.url = url
-        self.timeout = timeout
+        if isinstance(timeout, float):
+            self.timeout = Timeout(total_timeout=timeout)
         self.api_token = api_token
         self.broker_name = broker_name
         self._pending: set[asyncio.Task[Any]] = set()
-        self._client: httpx.AsyncClient | None = None
+        self._client: zapros.AsyncClient | None = None
 
     @staticmethod
     def _now_iso() -> str:
         return datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
 
-    def _get_client(self) -> httpx.AsyncClient:
+    def _get_client(self) -> zapros.AsyncClient:
         """Create and cache session."""
         if self._client is None:
-            self._client = httpx.AsyncClient(timeout=self.timeout)
+            self._client = zapros.AsyncClient(handler=zapros.AsyncStdNetworkHandler(**self.timeout))
         return self._client
 
     async def startup(self) -> None:
@@ -86,11 +101,9 @@ class DashboardMiddleware(TaskiqMiddleware):
                     json=payload,
                 )
                 resp.raise_for_status()
-                if not resp.is_success:
-                    logger.error('POST %s - %s', endpoint, resp.status_code)
-            except httpx.HTTPStatusError:
-                logger.exception('POST %s failed with HTTP error', endpoint)
-            except httpx.RequestError:
+                if resp.status >= 400:  # noqa: PLR2004
+                    logger.error('POST %s - %s', endpoint, resp.status)
+            except zapros.ZaprosError:
                 logger.exception('POST %s failed with request error', endpoint)
 
         task = asyncio.create_task(_send())

--- a/tests/integration/test_api/test_event_handler.py
+++ b/tests/integration/test_api/test_event_handler.py
@@ -1,21 +1,22 @@
 import uuid
 from collections.abc import AsyncGenerator
 from typing import Any
+from urllib.parse import urljoin
 
 import pytest
-from fastapi.testclient import TestClient
-from httpx import ASGITransport, AsyncClient
 from pydantic import SecretStr
 from taskiq import TaskiqMessage
+from zapros import AsgiHandler, AsyncClient
 
 from taskiq_dashboard import DashboardMiddleware
 from taskiq_dashboard.api.application import get_application
 from taskiq_dashboard.domain.dto.task_status import TaskStatus
 from taskiq_dashboard.infrastructure import get_settings
+from taskiq_dashboard.infrastructure.settings import PostgresSettings
 
 
 class TaskiqAdminWithTestClientMiddleware(DashboardMiddleware):
-    """Test middleware where I replace httpx client with test client."""
+    """Test middleware where I replace zapros client with test client."""
 
     def __init__(
         self,
@@ -35,18 +36,18 @@ class TaskiqAdminWithTestClientMiddleware(DashboardMiddleware):
 
     async def _spawn_request(self, endpoint: str, payload: dict[str, Any]) -> None:
         response = await self._test_client.post(
-            url=endpoint,
+            urljoin(self.url, endpoint),
             headers={'access-token': self.api_token},
             json=payload,
         )
-        assert response.status_code == 204
+        assert response.status == 204
 
 
 @pytest.fixture
-async def test_app() -> AsyncGenerator[AsyncClient]:
+async def test_app(database: PostgresSettings) -> AsyncGenerator[AsyncClient]:
     settings = get_settings()
     settings.api.token = SecretStr('test-token')
-    async with AsyncClient(transport=ASGITransport(app=get_application()), base_url='http://test') as client:
+    async with AsyncClient(handler=AsgiHandler(app=get_application(), startup_timeout=5.0)) as client:
         yield client
 
 
@@ -64,7 +65,7 @@ async def middleware(test_app: AsyncClient) -> TaskiqAdminWithTestClientMiddlewa
 class TestAppHandlesMiddlewareRequests:
     async def test_when_post_send_event_send__then_creates_task_with_status_queued(
         self,
-        test_app: TestClient,
+        test_app: AsyncClient,
         middleware: TaskiqAdminWithTestClientMiddleware,
         task_service,
     ) -> None:

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -1,13 +1,21 @@
 import asyncio
-import json
 import re
 from collections.abc import AsyncGenerator
 
-import httpx
 import pytest
+import zapros
 from polyfactory.factories.pydantic_factory import ModelFactory
-from pytest_httpx import HTTPXMock
 from taskiq import TaskiqMessage, TaskiqResult
+from zapros import Response
+from zapros.matchers import and_
+from zapros.mock import (
+    HeaderMatcher,
+    JsonMatcher,
+    Matcher,
+    MethodMatcher,
+    Mock,
+    mock_http,
+)
 
 from taskiq_dashboard import DashboardMiddleware
 
@@ -29,61 +37,81 @@ async def middleware() -> AsyncGenerator[DashboardMiddleware]:
     await middleware.shutdown()
 
 
+class PathRegexpMatcher(Matcher):
+    def __init__(self, path: str | re.Pattern[str]) -> None:
+        self._path = path
+
+    def match(self, request) -> bool:
+        if isinstance(self._path, re.Pattern):
+            return self._path.match(request.url.pathname) is not None
+        return self._path == request.url.pathname
+
+
 @pytest.mark.parametrize(
-    'method',
+    'taskiq_method',
     ['post_send', 'pre_execute', 'post_execute'],
 )
 async def test_when_middleware_method_called__then_request_send_with_auth_data(
-    httpx_mock: HTTPXMock,
     middleware: DashboardMiddleware,
-    method: str,
+    taskiq_method: str,
 ) -> None:
     # given
     message = TaskiqMessageFactory.build()
-    httpx_mock.add_response(
-        method='POST',
-        url=re.compile(f'http://test_dashboard/api/tasks/{message.task_id}/.*'),
-        status_code=200,
-    )
+    with mock_http() as router:
+        mocked = (
+            Mock.given(
+                and_(
+                    MethodMatcher('POST'),
+                    PathRegexpMatcher(re.compile(f'/api/tasks/{message.task_id}/.*')),
+                    HeaderMatcher('access-token', 'supersecret'),
+                )
+            )
+            .respond(Response(status=200))
+            .mount(router)
+            .once()
+        )
 
-    # when
-    if method == 'post_send':
-        await middleware.post_send(message)
-    elif method == 'pre_execute':
-        await middleware.pre_execute(message)
-    elif method == 'post_execute':
-        await middleware.post_execute(message, result=TaskiqResult(is_err=False, return_value=None, execution_time=1.0))
-    await asyncio.gather(*middleware._pending, return_exceptions=True)
+        # when
+        if taskiq_method == 'post_send':
+            await middleware.post_send(message)
+        elif taskiq_method == 'pre_execute':
+            await middleware.pre_execute(message)
+        elif taskiq_method == 'post_execute':
+            await middleware.post_execute(
+                message, result=TaskiqResult(is_err=False, return_value=None, execution_time=1.0)
+            )
+        await asyncio.gather(*middleware._pending, return_exceptions=True)
 
-    # then
-    request = httpx_mock.get_request()
-    assert request is not None
-    assert request.method == 'POST'
-    assert 'access-token' in request.headers
-    assert request.headers['access-token'] == 'supersecret'
+        # then
+        mocked.verify()
 
 
 async def test_when_middleware_shutdown__then_pending_requests_awaited(
-    httpx_mock: HTTPXMock,
     middleware: DashboardMiddleware,
 ) -> None:
     # given
     message = TaskiqMessageFactory.build()
-    httpx_mock.add_response(
-        method='POST',
-        url=re.compile(f'http://test_dashboard/api/tasks/{message.task_id}/.*'),
-        status_code=200,
-    )
+    with mock_http() as router:
+        mocked = (
+            Mock.given(
+                and_(
+                    MethodMatcher('POST'),
+                    PathRegexpMatcher(re.compile(f'/api/tasks/{message.task_id}/.*')),
+                    HeaderMatcher('access-token', 'supersecret'),
+                )
+            )
+            .respond(Response(status=200))
+            .mount(router)
+            .once()
+        )
 
-    # when
-    await middleware.post_send(message)
+        # when
+        await middleware.post_send(message)
 
-    # then
-    assert len(middleware._pending) > 0, 'Expected pending tasks'
-    await asyncio.gather(*middleware._pending, return_exceptions=True)
-    request = httpx_mock.get_request()
-    assert request is not None
-    assert request.method == 'POST'
+        # then
+        assert len(middleware._pending) > 0, 'Expected pending tasks'
+        await asyncio.gather(*middleware._pending, return_exceptions=True)
+        mocked.verify()
 
 
 async def test_when_middleware_startup__then_client_created(
@@ -92,7 +120,7 @@ async def test_when_middleware_startup__then_client_created(
     # given & when already done in fixture
     # then
     assert middleware._client is not None
-    assert isinstance(middleware._client, httpx.AsyncClient)
+    assert isinstance(middleware._client, zapros.AsyncClient)
 
 
 @pytest.mark.parametrize(
@@ -117,7 +145,6 @@ async def test_when_middleware_startup__then_client_created(
     ],
 )
 async def test_when_basic_parameters_are_passed__then_serialization_works(
-    httpx_mock: HTTPXMock,
     middleware: DashboardMiddleware,
     parameters: dict[str, list | dict],
 ) -> None:
@@ -126,25 +153,26 @@ async def test_when_basic_parameters_are_passed__then_serialization_works(
         args=parameters['args'],
         kwargs=parameters['kwargs'],
     )
-    httpx_mock.add_response(
-        method='POST',
-        url=re.compile(f'http://test_dashboard/api/tasks/{message.task_id}/.*'),
-        status_code=200,
-    )
+    with mock_http() as router:
+        mocked = (
+            Mock.given(
+                and_(
+                    MethodMatcher('POST'),
+                    PathRegexpMatcher(re.compile(f'/api/tasks/{message.task_id}/.*')),
+                    HeaderMatcher('access-token', 'supersecret'),
+                    JsonMatcher(
+                        lambda body: body['args'] == parameters['args'] and body['kwargs'] == parameters['kwargs']
+                    ),
+                )
+            )
+            .respond(Response(status=200))
+            .mount(router)
+            .once()
+        )
 
-    # when
-    await middleware.post_send(message)
-    await asyncio.gather(*middleware._pending, return_exceptions=True)
+        # when
+        await middleware.post_send(message)
+        await asyncio.gather(*middleware._pending, return_exceptions=True)
 
-    # then
-    request = httpx_mock.get_request()
-    assert request is not None
-    assert request.method == 'POST'
-
-    payload = request.content
-    assert b'"args"' in payload
-    assert b'"kwargs"' in payload
-
-    json_payload = json.loads(payload)
-    assert json_payload['args'] == parameters['args']
-    assert json_payload['kwargs'] == parameters['kwargs']
+        # then
+        mocked.verify()

--- a/uv.lock
+++ b/uv.lock
@@ -273,15 +273,6 @@ wheels = [
 ]
 
 [[package]]
-name = "certifi"
-version = "2025.1.31"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload-time = "2025-01-31T02:16:47.166Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload-time = "2025-01-31T02:16:45.015Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -804,39 +795,11 @@ wheels = [
 
 [[package]]
 name = "h11"
-version = "0.14.0"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418, upload-time = "2022-09-25T15:40:01.519Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259, upload-time = "2022-09-25T15:39:59.68Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/45/ad3e1b4d448f22c0cff4f5692f5ed0666658578e358b8d58a19846048059/httpcore-1.0.8.tar.gz", hash = "sha256:86e94505ed24ea06514883fd44d2bc02d90e77e7979c8eb71b90f41d364a1bad", size = 85385, upload-time = "2025-04-11T14:42:46.661Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/8d/f052b1e336bb2c1fc7ed1aaed898aa570c0b61a09707b108979d9fc6e308/httpcore-1.0.8-py3-none-any.whl", hash = "sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be", size = 78732, upload-time = "2025-04-11T14:42:44.896Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -1552,19 +1515,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-httpx"
-version = "0.36.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/42/f53c58570e80d503ade9dd42ce57f2915d14bcbe25f6308138143950d1d6/pytest_httpx-0.36.2.tar.gz", hash = "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356", size = 57683, upload-time = "2026-04-09T13:57:19.837Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/55/1fa65f8e4fceb19dd6daa867c162ad845d547f6058cd92b4b02384a44777/pytest_httpx-0.36.2-py3-none-any.whl", hash = "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22", size = 20315, upload-time = "2026-04-09T13:57:18.587Z" },
-]
-
-[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1580,6 +1530,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "pywhatwgurl"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/d2/ce0fffb9eb66ea2f88d20d7c3841b017d25559b6b617bce566811fe0bb48/pywhatwgurl-0.1.1.tar.gz", hash = "sha256:65c85da35367511c12a4dd87fecaf08aa3ae564259055b37b4ae53429289fcf6", size = 155366, upload-time = "2026-04-03T08:20:13.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/2f/6e14535f7532c836c1200ea53785570d3c37128719ff62915d0971e00598/pywhatwgurl-0.1.1-py3-none-any.whl", hash = "sha256:d67072d3f702f899e6e5de074e7fa14b5c9c5c85f616c6016c4eef9c94113d5f", size = 26605, upload-time = "2026-04-03T08:20:12.46Z" },
 ]
 
 [[package]]
@@ -1885,12 +1847,12 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "dishka" },
     { name = "fastapi" },
-    { name = "httpx" },
     { name = "jinja2" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "sqlalchemy", extra = ["asyncio", "postgresql-asyncpg"] },
     { name = "taskiq" },
+    { name = "zapros" },
 ]
 
 [package.optional-dependencies]
@@ -1909,7 +1871,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-deadfixtures" },
-    { name = "pytest-httpx" },
     { name = "ruff" },
     { name = "sqlalchemy-utils" },
     { name = "taskiq-postgres", extra = ["asyncpg"] },
@@ -1937,7 +1898,6 @@ test = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-deadfixtures" },
-    { name = "pytest-httpx" },
     { name = "sqlalchemy-utils" },
 ]
 
@@ -1947,12 +1907,12 @@ requires-dist = [
     { name = "dishka", specifier = ">=1.7.2" },
     { name = "fastapi", specifier = ">=0.134.0" },
     { name = "granian", marker = "extra == 'server'", specifier = ">=2.6.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "sqlalchemy", extras = ["asyncio", "postgresql-asyncpg"], specifier = ">=2.0.45" },
     { name = "taskiq", specifier = ">=0.12.1" },
+    { name = "zapros", git = "https://github.com/kap-sh/zapros?rev=f35c63bfbe3975ebee3b2de7cbf51a3bb1ffc1d0" },
 ]
 provides-extras = ["server"]
 
@@ -1967,7 +1927,6 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-deadfixtures", specifier = ">=3.1.0" },
-    { name = "pytest-httpx", specifier = ">=0.36.2" },
     { name = "ruff", specifier = ">=0.15.11" },
     { name = "sqlalchemy-utils", specifier = ">=0.42.1" },
     { name = "taskiq-postgres", extras = ["asyncpg"], specifier = ">=0.7.0" },
@@ -1991,7 +1950,6 @@ test = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-deadfixtures", specifier = ">=3.1.0" },
-    { name = "pytest-httpx", specifier = ">=0.36.2" },
     { name = "sqlalchemy-utils", specifier = ">=0.42.1" },
 ]
 
@@ -2113,11 +2071,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
@@ -2265,6 +2223,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zapros"
+version = "0.11.0"
+source = { git = "https://github.com/kap-sh/zapros?rev=f35c63bfbe3975ebee3b2de7cbf51a3bb1ffc1d0#f35c63bfbe3975ebee3b2de7cbf51a3bb1ffc1d0" }
+dependencies = [
+    { name = "h11" },
+    { name = "pywhatwgurl" },
+    { name = "typing-extensions" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1912,7 +1912,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "sqlalchemy", extras = ["asyncio", "postgresql-asyncpg"], specifier = ">=2.0.45" },
     { name = "taskiq", specifier = ">=0.12.1" },
-    { name = "zapros", git = "https://github.com/kap-sh/zapros?rev=f35c63bfbe3975ebee3b2de7cbf51a3bb1ffc1d0" },
+    { name = "zapros", specifier = ">=0.11.1" },
 ]
 provides-extras = ["server"]
 
@@ -2227,12 +2227,16 @@ wheels = [
 
 [[package]]
 name = "zapros"
-version = "0.11.0"
-source = { git = "https://github.com/kap-sh/zapros?rev=f35c63bfbe3975ebee3b2de7cbf51a3bb1ffc1d0#f35c63bfbe3975ebee3b2de7cbf51a3bb1ffc1d0" }
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
     { name = "pywhatwgurl" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/47/42c85e3eaa4e2cdabe22a2f3d4255e135c975f725c169bae4ba9ef4ec0c0/zapros-0.11.1.tar.gz", hash = "sha256:cfb8da486d2d68ff37b3c2c647cd7a0329e64e228f5e8f929856f4a4a5c41f38", size = 928904, upload-time = "2026-05-07T06:48:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/f8/1c40af1077b23de28d669e3389f6e75150c671b743c00e498408acceb036/zapros-0.11.1-py3-none-any.whl", hash = "sha256:600119d063377b5eb7136572dbadbe6c6e8233eda5cb895b82eec7386e793c08", size = 96468, upload-time = "2026-05-07T06:47:58.802Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Features:
- replace httpx with zapros library (less bloated lib)

Fixes:
- always install `greenlet` with sqlalchemy for async features

Docs:
- add dedicated page about running dashboard as mounted app